### PR TITLE
feat: initialize scaffolding for auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "expo-status-bar": "~2.2.3",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-hook-form": "^7.63.0",
         "react-native": "0.80.1",
         "react-native-safe-area-context": "5.5.2",
         "react-native-screens": "4.11.1",
@@ -7178,6 +7179,22 @@
       },
       "peerDependencies": {
         "react": ">=17.0.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.63.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.63.0.tgz",
+      "integrity": "sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -22,16 +22,17 @@
     "expo": "~53.0.19",
     "expo-constants": "~17.1.7",
     "expo-font": "~13.3.2",
+    "expo-linking": "~7.1.7",
+    "expo-router": "~5.1.6",
     "expo-splash-screen": "~0.30.10",
     "expo-status-bar": "~2.2.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hook-form": "^7.63.0",
     "react-native": "0.80.1",
     "react-native-safe-area-context": "5.5.2",
     "react-native-screens": "4.11.1",
-    "react-native-web": "~0.20.0",
-    "expo-router": "~5.1.6",
-    "expo-linking": "~7.1.7"
+    "react-native-web": "~0.20.0"
   },
   "devDependencies": {
     "@babel/core": "^7.28.0",

--- a/src/api/profiles.ts
+++ b/src/api/profiles.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../supabase';
+
+export interface Profile {
+  id: string;
+  full_name?: string | null;
+  avatar_url?: string | null;
+  email?: string | null;
+  updated_at?: string | null;
+}
+
+export async function getProfile(userId: string): Promise<{ data: Profile | null; error: any }> {
+  const res = await supabase.from('profiles').select('*').eq('id', userId).maybeSingle();
+  return { data: res.data as Profile | null, error: res.error };
+}
+
+export async function upsertProfile(profile: Partial<Profile>): Promise<{ data: Profile | null; error: any }> {
+  // Supabase upsert -> select -> maybeSingle to return the row
+  const res = await supabase.from('profiles').upsert(profile).select().maybeSingle();
+  return { data: res.data as Profile | null, error: res.error };
+}

--- a/src/app/(private)/profile.tsx
+++ b/src/app/(private)/profile.tsx
@@ -1,0 +1,33 @@
+import {StyleSheet, View} from 'react-native'
+import { Text} from "../../components/ui";
+
+import {useAuth} from "../../hooks/useAuth";
+import PageView from "../../components/ui/PageView";
+import SignOutButton from "../../components/user/SignOutButton";
+
+export default function ProfileRoute() {
+    const { profile } = useAuth()
+    return (
+        <PageView title="Profile &amp; Settings">
+            <View style={styles.titleContainer}>
+                <Text>Welcome!</Text>
+            </View>
+            <View style={styles.stepContainer}>
+                <Text>{profile?.username}</Text>
+                <Text>{profile?.full_name}</Text>
+            </View>
+            <SignOutButton />
+        </PageView>
+    )
+}
+const styles = StyleSheet.create({
+    titleContainer: {
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 8,
+    },
+    stepContainer: {
+        gap: 8,
+        marginBottom: 8,
+    },
+})

--- a/src/app/_layout.tsx
+++ b/src/app/_layout.tsx
@@ -11,6 +11,9 @@ import {
 import {CityProvider} from "../context/CityContext";
 import {ThemeProvider} from "../context/ThemeContext";
 import Header from "../components/Header";
+import {useAuth} from "../hooks/useAuth";
+import AuthProvider from "../providers/auth-provider";
+import {SplashScreenController} from "../components/SplashScreenController";
 
 
 SplashScreen.preventAutoHideAsync();
@@ -44,15 +47,27 @@ export default function RootLayout() {
     // error state
 
     return (
-            <ThemeProvider>
+        <ThemeProvider>
+            <AuthProvider>
                 <CityProvider>
+                    <SplashScreenController />
                     <RootNavigator />
                 </CityProvider>
-            </ThemeProvider>
+            </AuthProvider>
+        </ThemeProvider>
     );
 }
 
 // Separate this into a new component so it can access the SessionProvider context later
 function RootNavigator() {
-    return <Stack screenOptions={{ header: Header }} initialRouteName="index"/>
+    const { isLoggedIn } = useAuth()
+    return <Stack screenOptions={{ header: Header }} initialRouteName="index">
+        <Stack.Protected guard={isLoggedIn}>
+            <Stack.Screen name="(private)" options={{ headerShown: false }} />
+        </Stack.Protected>
+        <Stack.Protected guard={!isLoggedIn}>
+            <Stack.Screen name="login" options={{ headerShown: false }} />
+        </Stack.Protected>
+        <Stack.Screen name="+not-found" />
+    </Stack>
 }

--- a/src/app/user/reset.tsx
+++ b/src/app/user/reset.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import ResetPassword from "../../components/user/ResetPassword";
+import PageView from "../../components/ui/PageView";
+
+export default function ResetRoute() {
+    return (
+        <>
+            <PageView title="Reset Password">
+                <ResetPassword />
+            </PageView>
+        </>
+    )
+}

--- a/src/app/user/signin.tsx
+++ b/src/app/user/signin.tsx
@@ -1,0 +1,11 @@
+import SignIn from "../../components/user/SignIn";
+import React from "react";
+import PageView from "../../components/ui/PageView";
+
+export default function SignInRoute() {
+    return (
+        <PageView title="Sign In">
+            <SignIn />
+        </PageView>
+    )
+}

--- a/src/app/user/signup.tsx
+++ b/src/app/user/signup.tsx
@@ -1,0 +1,13 @@
+import {Text} from "../../components/ui";
+import {View, StyleSheet} from "react-native";
+import {theme} from "../../theme";
+import SignUp from "../../components/user/SignUp";
+import PageView from "../../components/ui/PageView";
+
+export default function SignUpRoute() {
+    return (
+        <PageView title="Sign Up">
+            <SignUp />
+        </PageView>
+    )
+}

--- a/src/components/SplashScreenController.tsx
+++ b/src/components/SplashScreenController.tsx
@@ -1,0 +1,12 @@
+
+import { SplashScreen } from 'expo-router'
+import {useAuth} from "../hooks/useAuth";
+SplashScreen.preventAutoHideAsync()
+
+export function SplashScreenController() {
+    const { isLoading } = useAuth()
+    if (!isLoading) {
+        SplashScreen.hideAsync()
+    }
+    return null
+}

--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { TextInput, StyleSheet, View, TextInputProps } from 'react-native';
+import { useTheme } from '../../context/ThemeContext';
+import { Text } from './Text';
+
+interface InputProps extends TextInputProps {
+  label?: string;
+  error?: string;
+}
+
+export function Input({ label, error, style, ...rest }: InputProps) {
+  const { theme } = useTheme();
+
+  return (
+    <View style={styles.container}>
+      {label && <Text variant="label" style={styles.label}>{label}</Text>}
+      <TextInput
+        style={[
+          styles.input,
+          {
+            backgroundColor: theme.colors.background.secondary,
+            color: theme.colors.text.primary,
+            borderColor: error ? theme.colors.error : theme.colors.border.medium,
+          },
+          style,
+        ]}
+        placeholderTextColor={theme.colors.text.secondary}
+        {...rest}
+      />
+      {error && <Text variant="caption" color="error" style={styles.error}>{error}</Text>}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    width: '100%',
+    marginVertical: 8,
+  },
+  label: {
+    marginBottom: 4,
+    marginLeft: 2,
+  },
+  input: {
+    borderWidth: 1,
+    borderRadius: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    fontSize: 16,
+  },
+  error: {
+    marginTop: 4,
+    marginLeft: 2,
+  },
+});
+
+export default Input;

--- a/src/components/ui/PageView.tsx
+++ b/src/components/ui/PageView.tsx
@@ -1,0 +1,32 @@
+import React, {PropsWithChildren} from "react";
+import {StyleSheet, View} from "react-native";
+import {Text} from "./Text";
+
+type PageViewProps = PropsWithChildren & {
+    title?: string;
+}
+export default function PageView({children, title}: PageViewProps ) {
+    return (
+        <View style={styles.container}>
+            <Text variant="h3">{title}</Text>
+            {children}
+        </View>
+    )
+}
+
+const styles = StyleSheet.create({
+    container: {
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 20,
+    },
+    title: {
+        fontSize: 24,
+        fontWeight: 'bold',
+        marginBottom: 20,
+    },
+    subtitle: {
+        fontSize: 16,
+        marginBottom: 20,
+    },
+})

--- a/src/components/ui/Text.tsx
+++ b/src/components/ui/Text.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { Text as RNText, TextProps as RNTextProps, StyleSheet } from 'react-native';
-import { useTheme } from '../../context/ThemeContext';
+import {ThemeContextType, useTheme} from '../../context/ThemeContext';
 
-export type TextVariant = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'body1' | 'body2' | 'caption' | 'overline' | 'link';
-export type TextColor = 'primary' | 'secondary' | 'tertiary' | 'inverse' | 'success' | 'warning' | 'error' | 'info';
+export type TextVariant = keyof ReturnType<typeof buildVariantStyles>;
+export type TextColor = keyof ReturnType<typeof buildColorStyles>;
 
 interface TextProps extends Omit<RNTextProps, 'style'> {
   variant?: TextVariant;
@@ -11,6 +11,83 @@ interface TextProps extends Omit<RNTextProps, 'style'> {
   align?: 'left' | 'center' | 'right' | 'justify';
   style?: RNTextProps['style'];
 }
+
+const buildVariantStyles = (theme: ThemeContextType['theme']) => ({
+  h1: {
+    fontSize: theme.typography.fontSize['4xl'],
+    lineHeight: theme.typography.lineHeight['4xl'],
+    fontFamily: theme.typography.fontFamily.bold,
+  },
+  h2: {
+    fontSize: theme.typography.fontSize['3xl'],
+    lineHeight: theme.typography.lineHeight['3xl'],
+    fontFamily: theme.typography.fontFamily.bold,
+  },
+  h3: {
+    fontSize: theme.typography.fontSize['2xl'],
+    lineHeight: theme.typography.lineHeight['2xl'],
+    fontFamily: theme.typography.fontFamily.semibold,
+  },
+  h4: {
+    fontSize: theme.typography.fontSize.xl,
+    lineHeight: theme.typography.lineHeight.xl,
+    fontFamily: theme.typography.fontFamily.semibold,
+  },
+  h5: {
+    fontSize: theme.typography.fontSize.lg,
+    lineHeight: theme.typography.lineHeight.lg,
+    fontFamily: theme.typography.fontFamily.medium,
+  },
+  h6: {
+    fontSize: theme.typography.fontSize.base,
+    lineHeight: theme.typography.lineHeight.base,
+    fontFamily: theme.typography.fontFamily.medium,
+  },
+  body1: {
+    fontSize: theme.typography.fontSize.base,
+    lineHeight: theme.typography.lineHeight.base,
+    fontFamily: theme.typography.fontFamily.regular,
+  },
+  body2: {
+    fontSize: theme.typography.fontSize.sm,
+    lineHeight: theme.typography.lineHeight.sm,
+    fontFamily: theme.typography.fontFamily.regular,
+  },
+  caption: {
+    fontSize: theme.typography.fontSize.xs,
+    lineHeight: theme.typography.lineHeight.xs,
+    fontFamily: theme.typography.fontFamily.regular,
+  },
+  overline: {
+    fontSize: theme.typography.fontSize.xs,
+    lineHeight: theme.typography.lineHeight.xs,
+    fontFamily: theme.typography.fontFamily.medium,
+    textTransform: 'uppercase' as const,
+    letterSpacing: 1,
+  },
+  link: {
+    fontSize: theme.typography.fontSize.xs,
+    lineHeight: theme.typography.lineHeight.xs,
+    fontFamily: theme.typography.fontFamily.medium,
+    textDecorationLine: 'underline',
+  },
+  label: {
+    fontSize: theme.typography.fontSize.sm,
+    lineHeight: theme.typography.lineHeight.sm,
+    fontFamily: theme.typography.fontFamily.medium,
+  },
+});
+
+const buildColorStyles = (theme: ThemeContextType['theme']) => ({
+  primary: { color: theme.colors.text.primary },
+  secondary: { color: theme.colors.text.secondary },
+  tertiary: { color: theme.colors.text.tertiary },
+  inverse: { color: theme.colors.text.inverse },
+  success: { color: theme.colors.success },
+  warning: { color: theme.colors.warning },
+  error: { color: theme.colors.error },
+  info: { color: theme.colors.info },
+});
 
 export const Text: React.FC<TextProps> = ({
   children,
@@ -23,77 +100,8 @@ export const Text: React.FC<TextProps> = ({
   const { theme } = useTheme();
 
   const getTextStyles = () => {
-    const variantStyles = {
-      h1: {
-        fontSize: theme.typography.fontSize['4xl'],
-        lineHeight: theme.typography.lineHeight['4xl'],
-        fontFamily: theme.typography.fontFamily.bold,
-      },
-      h2: {
-        fontSize: theme.typography.fontSize['3xl'],
-        lineHeight: theme.typography.lineHeight['3xl'],
-        fontFamily: theme.typography.fontFamily.bold,
-      },
-      h3: {
-        fontSize: theme.typography.fontSize['2xl'],
-        lineHeight: theme.typography.lineHeight['2xl'],
-        fontFamily: theme.typography.fontFamily.semibold,
-      },
-      h4: {
-        fontSize: theme.typography.fontSize.xl,
-        lineHeight: theme.typography.lineHeight.xl,
-        fontFamily: theme.typography.fontFamily.semibold,
-      },
-      h5: {
-        fontSize: theme.typography.fontSize.lg,
-        lineHeight: theme.typography.lineHeight.lg,
-        fontFamily: theme.typography.fontFamily.medium,
-      },
-      h6: {
-        fontSize: theme.typography.fontSize.base,
-        lineHeight: theme.typography.lineHeight.base,
-        fontFamily: theme.typography.fontFamily.medium,
-      },
-      body1: {
-        fontSize: theme.typography.fontSize.base,
-        lineHeight: theme.typography.lineHeight.base,
-        fontFamily: theme.typography.fontFamily.regular,
-      },
-      body2: {
-        fontSize: theme.typography.fontSize.sm,
-        lineHeight: theme.typography.lineHeight.sm,
-        fontFamily: theme.typography.fontFamily.regular,
-      },
-      caption: {
-        fontSize: theme.typography.fontSize.xs,
-        lineHeight: theme.typography.lineHeight.xs,
-        fontFamily: theme.typography.fontFamily.regular,
-      },
-      overline: {
-        fontSize: theme.typography.fontSize.xs,
-        lineHeight: theme.typography.lineHeight.xs,
-        fontFamily: theme.typography.fontFamily.medium,
-        textTransform: 'uppercase' as const,
-        letterSpacing: 1,
-      },
-      link: {
-        fontSize: theme.typography.fontSize.xs,
-        lineHeight: theme.typography.lineHeight.xs,
-        fontFamily: theme.typography.fontFamily.medium,
-        textDecorationLine: 'underline',
-      }
-    };
-
-    const colorStyles = {
-      primary: { color: theme.colors.text.primary },
-      secondary: { color: theme.colors.text.secondary },
-      tertiary: { color: theme.colors.text.tertiary },
-      inverse: { color: theme.colors.text.inverse },
-      success: { color: theme.colors.success },
-      warning: { color: theme.colors.warning },
-      error: { color: theme.colors.error },
-      info: { color: theme.colors.info },
-    };
+    const variantStyles = buildVariantStyles(theme);
+    const colorStyles = buildColorStyles(theme);
 
     return [
       variantStyles[variant],

--- a/src/components/ui/index.ts
+++ b/src/components/ui/index.ts
@@ -1,30 +1,24 @@
 export { Button } from './Button';
-export type { ButtonVariant, ButtonSize } from './Button';
-
-export { Text } from './Text';
-export type { TextVariant, TextColor } from './Text';
-
+export type {
+    ButtonVariant,
+    ButtonSize
+} from './Button';
 export { Card } from './Card';
-export type { CardVariant } from './Card';
-
-export { Container } from './Container';
-
-export { ThemeToggle } from './ThemeToggle';
-
-export { SearchableDropdown } from './SearchableDropdown';
-
-export { DateRangePicker } from './DateRangePicker';
-
-export { Portal } from './Portal';
-
-export { default as VenueSelectionModal } from './VenueSelectionModal';
-
-export { CityPicker } from './CityPicker';
-
 export { CategoryPills } from './CategoryPills';
-
+export { CityPicker } from './CityPicker';
+export type { CardVariant } from './Card';
+export { Container } from './Container';
+export { DateRangePicker } from './DateRangePicker';
 export { FilterRow } from './FilterRow';
-
+export { Input} from './Input'
+export { Portal } from './Portal';
+export { SearchableDropdown } from './SearchableDropdown';
 export { SearchAndToggle } from './SearchAndToggle';
-
+export { Text } from './Text';
+export type {
+    TextVariant,
+    TextColor
+} from './Text';
+export { ThemeToggle } from './ThemeToggle';
+export { default as VenueSelectionModal } from './VenueSelectionModal';
 export { ViewToggle } from './ViewToggle';

--- a/src/components/user/ResetPassword.tsx
+++ b/src/components/user/ResetPassword.tsx
@@ -1,0 +1,98 @@
+import React, {useState} from "react";
+import {Controller, useForm} from "react-hook-form";
+import {supabase} from "../../supabase";
+import {Button, Text} from "../ui";
+import {ActivityIndicator, View} from "react-native";
+import {styles} from "./styles";
+import Input from "../ui/Input";
+import {Link} from "expo-router";
+
+type RestFormValues = {
+    newPassword: string;
+    confirmPassword: string;
+}
+
+export default function ResetPassword() {
+    const [loading, setLoading] = useState<boolean>(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const {
+        control,
+        handleSubmit,
+        formState: { errors },
+        watch
+    } = useForm<RestFormValues>({
+        defaultValues: {
+            newPassword: "",
+            confirmPassword: "",
+        },
+    });
+
+    const password = watch('newPassword');
+
+    async function passwordReset(values: RestFormValues) {
+        try {
+            setLoading(true);
+            const { data, error } = await supabase.auth.updateUser({ password: values.newPassword });
+            if (error) {
+                setFeedback(error.message);
+                return;
+            }
+            setFeedback('Password updated. You can now sign in.');
+        } catch (e: any) {
+            setFeedback(e?.message || 'Failed to update password');
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (<>
+        {loading && (
+            <View style={styles.loadingOverlay} pointerEvents="none">
+                <ActivityIndicator size="large" />
+            </View>
+        )}
+        {feedback && <Text variant="body2" color="info">{feedback}</Text>}
+        <Controller
+            control={control}
+            rules={{
+                required: true,
+                minLength: 8,
+            }}
+            render={({ field: { onChange, onBlur, value } }) => (
+                <Input
+                    label="New password"
+                    value={value}
+                    onBlur={onBlur}
+                    onChangeText={onChange}
+                    secureTextEntry
+                    placeholder="Enter new password"
+                    autoCapitalize='none'
+                />)}
+            name="newPassword"
+        />
+
+        <Controller
+            control={control}
+            rules={{
+                required: true,
+                validate: (value: string) => value === password || 'Passwords do not match',
+            }}
+            render={({ field: { onChange, onBlur, value } }) => (
+                <Input
+                    label="Confirm password"
+                    value={value}
+                    onBlur={onBlur}
+                    onChangeText={onChange}
+                    secureTextEntry
+                    placeholder="Enter new password"
+                    autoCapitalize={'none'}
+                    error={errors.confirmPassword?.message}
+                />)}
+            name="confirmPassword"
+        />
+        <View style={[styles.verticallySpaced, styles.mt20]}>
+            <Button title="Update password" variant="primary" onPress={handleSubmit(passwordReset)} />
+        </View>
+        <Link href="/user/signin">Back to sign in</Link>
+    </>)
+}

--- a/src/components/user/SignIn.tsx
+++ b/src/components/user/SignIn.tsx
@@ -1,0 +1,228 @@
+import { Controller, useForm} from "react-hook-form";
+import {View, Platform, ActivityIndicator} from "react-native";
+import {Button, Text} from "../ui";
+import {supabase} from "../../supabase";
+import React, {useState} from "react";
+import Input from "../ui/Input";
+import {Link} from "expo-router";
+import * as Linking from "expo-linking";
+import {styles} from "./styles";
+
+type LoginFormValues = {
+    email: string;
+    password: string;
+    resetEmail?: string;
+    linkEmail?: string;
+}
+
+export default function SignIn() {
+    const [loading, setLoading] = useState(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const [forgotMode, setForgotMode] = useState(false);
+    const [linkMode, setLinkMode] = useState(false);
+    const {
+        control,
+        handleSubmit,
+        formState: { errors },
+        watch,
+    } = useForm<LoginFormValues>({
+        defaultValues: {
+            email: "",
+            password: "",
+            resetEmail: '',
+        },
+    });
+
+    const email = watch('email');
+
+    async function signInWithEmail(values: LoginFormValues) {
+        setLoading(true);
+        try {
+            const { error } = await supabase.auth.signInWithPassword({
+                email: values.email,
+                password: values.password,
+            });
+            if (error) setFeedback(error.message);
+        } catch (err: any) {
+            setFeedback(`Reset failed ${err?.message || 'Unknown error'}`);
+        }
+        setLoading(false);
+    }
+
+    async function signInWithGoogle() {
+        setLoading(true);
+        try {
+            const redirectTo = Platform.OS === 'web' ? window.location.origin : Linking.createURL('/');
+            const { data, error } = await supabase.auth.signInWithOAuth({
+                provider: 'google',
+                options: { redirectTo },
+            });
+
+            if (error) {
+                const msg = (error.message || '').toLowerCase();
+                if (msg.includes('already')
+                    || msg.includes('duplicate')
+                    || msg.includes('account exists')
+                ) {
+                    setLinkMode(true);
+                }
+                setFeedback(`Google sign-in failed ${error.message}`);
+            }
+
+            if (data?.url && Platform.OS !== 'web') {
+                const supported = await Linking.canOpenURL(data.url);
+                if (supported) {
+                    await Linking.openURL(data.url);
+                } else {
+                    console.warn('Cannot open URL from Supabase OAuth', data.url);
+                }
+            }
+        } catch (err: any) {
+            setFeedback(`Google sign-in failed ${err?.message || 'Unknown error'}`);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function sendPasswordReset(values: LoginFormValues) {
+        setLoading(true);
+        const targetEmail = (values.resetEmail || email).trim();
+        try {
+            const redirectTo = Platform.OS === 'web' ? window.location.origin : Linking.createURL('/');
+            const { error } = await supabase.auth.resetPasswordForEmail(targetEmail, { redirectTo });
+            setFeedback(
+                error
+                    ? `Reset failed: ${error.message}`
+                    : `If you have an account, a reset email will be sent to ${targetEmail}`
+            );
+            setForgotMode(false);
+        } catch (err: any) {
+            setFeedback(`Reset failed ${err?.message || 'Unknown error'}`);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    async function sendMagicLinkForLinking(values: LoginFormValues) {
+        try {
+            setLoading(true);
+            const redirectTo = Platform.OS === 'web' ? window.location.origin : Linking.createURL('/');
+            const { data, error } = await supabase.auth.signInWithOtp({ email: values.email.trim(), options: { emailRedirectTo: redirectTo } });
+            setFeedback(error
+                ? `Failed to send sign-in link - ${error.message}`
+            : `A sign-in link has been sent to ${values.email.trim()}. Use it to link your Google account.`);
+            setLinkMode(false);
+        } catch (err: any) {
+            setFeedback(`Failed to send link - ${err?.message || 'Unknown error'}`);
+        }
+        setLoading(false);
+    }
+
+    return (
+        <>
+            {loading && (
+                <View style={styles.loadingOverlay} pointerEvents="none">
+                    <ActivityIndicator size="large" />
+                </View>
+            )}
+            {feedback && <Text variant="body2" color="info">{feedback}</Text>}
+            <Controller
+                control={control}
+                rules={{
+                    required: true,
+                }}
+                render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                        label="Email"
+                        placeholder="Email"
+                        onBlur={onBlur}
+                        onChangeText={onChange}
+                        value={value}
+                        autoCapitalize='none'
+                        error={errors.email?.message}
+                    />
+                )}
+                name="email"
+            />
+
+            <Controller
+                control={control}
+                rules={{
+                    maxLength: 100,
+                }}
+                render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                        label="Password"
+                        placeholder="Password"
+                        onBlur={onBlur}
+                        onChangeText={onChange}
+                        value={value}
+                        autoCapitalize='none'
+                        secureTextEntry
+                        error={errors.password?.message}
+                    />
+                )}
+                name="password"
+            />
+
+            <View style={[styles.verticallySpaced, styles.mt20]}>
+                <Button title="Sign in" disabled={loading} onPress={handleSubmit(signInWithEmail)} />
+            </View>
+            <View style={styles.verticallySpaced}>
+                <Button title="Continue with Google" variant="outline" onPress={() => signInWithGoogle()} />
+            </View>
+            <View style={styles.verticallySpaced}>
+                <Link href='/user/signup'>Need to Register?</Link>
+            </View>
+
+            {forgotMode && (
+                <View style={[styles.verticallySpaced, styles.mt20]}>
+                    <Controller
+                        control={control}
+                        render={({field: {onChange, onBlur, value}}) => (
+                            <Input
+                                label="Email for reset"
+                                value={email || value}
+                                onBlur={onBlur}
+                                onChangeText={onChange}
+                                placeholder="email@address.com"
+                                autoCapitalize='none'
+                            />
+                        )}
+                        name="resetEmail"
+                    />
+                    <View style={[styles.verticallySpaced, styles.mt20]}>
+                        <Button
+                            title="Send reset link"
+                            variant="primary"
+                            onPress={handleSubmit(sendPasswordReset)}
+                        />
+                    </View>
+                </View>)
+            }
+
+            {linkMode && (
+                <View style={styles.verticallySpaced}>
+                    <Text variant="body2">It looks like a Google account already exists with this email. Enter that email below to receive a sign-in link and then link your Google account from your profile.</Text>
+                    <Controller
+                        control={control}
+                        render={({field: {onChange, onBlur, value}}) => (
+                            <Input
+                                label="Email associated with Google"
+                                value={email || value}
+                                onBlur={onBlur}
+                                onChangeText={onChange}
+                                placeholder="email@address.com"
+                                autoCapitalize='none'
+                            />
+                        )}
+                        name="linkEmail"
+                    />
+                    <View style={[styles.verticallySpaced, styles.mt20]}>
+                        <Button title="Send sign-in link" variant="primary" onPress={handleSubmit(sendMagicLinkForLinking)} loading={loading} />
+                    </View>
+                </View>)
+            }
+        </>
+    )
+}

--- a/src/components/user/SignOutButton.tsx
+++ b/src/components/user/SignOutButton.tsx
@@ -1,0 +1,14 @@
+import * as React from 'react';
+import { Button } from 'react-native';
+import {supabase} from "../../supabase";
+
+async function onSignOutButtonPress() {
+    const { error } = await supabase.auth.signOut()
+    if (error) {
+        console.error('Error signing out:', error)
+    }
+}
+
+export default function SignOutButton() {
+    return <Button title="Sign out" onPress={onSignOutButtonPress} />
+}

--- a/src/components/user/SignUp.tsx
+++ b/src/components/user/SignUp.tsx
@@ -1,0 +1,119 @@
+import {Controller, useForm} from "react-hook-form";
+import {View, Alert, Platform, ActivityIndicator} from "react-native";
+import {Button, Text} from "../ui";
+import {supabase} from "../../supabase";
+import React, {useState} from "react";
+import Input from "../ui/Input";
+import {Link} from "expo-router";
+import {styles} from "./styles";
+import * as Linking from "expo-linking";
+
+type LoginFormValues = {
+    email: string;
+    password: string;
+}
+
+export default function SignUp() {
+    const [loading, setLoading] = useState(false);
+    const [feedback, setFeedback] = useState<string | null>(null);
+    const {
+        control,
+        handleSubmit,
+        formState: { errors },
+    } = useForm<LoginFormValues>({
+        defaultValues: {
+            email: "",
+            password: "",
+        },
+    })
+
+    async function signUpWithEmail(values: LoginFormValues) {
+        setLoading(true);
+        const {
+            data: { session },
+            error,
+        } = await supabase.auth.signUp({
+            email: values.email,
+            password: values.password,
+        })
+        if (error) Alert.alert(error.message)
+        if (!session) Alert.alert('Please check your inbox for email verification!')
+        setLoading(false);
+    }
+
+    async function resendConfirmationEmail(values: LoginFormValues) {
+        try {
+            setLoading(true);
+            const redirectTo = Platform.OS === 'web' ? window.location.origin : Linking.createURL('/');
+            const { error } = await (supabase.auth as any).resend({
+                type: 'signup',
+                email: values.email.trim(),
+                options: { emailRedirectTo: redirectTo },
+            });
+            if (error) {
+                setFeedback(`Resend failed - ${error.message}`);
+                return;
+            }
+            setFeedback('Confirmation email resent. Please check your inbox (and spam).');
+        } catch (e: any) {
+            setFeedback(`Failed to resend confirmation email - ${e?.message || 'Unknown error'}`);
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    return (
+        <>
+            {loading && (
+                <View style={styles.loadingOverlay} pointerEvents="none">
+                    <ActivityIndicator size="large" />
+                </View>
+            )}
+            {feedback && <Text variant="body2" color="info">{feedback}</Text>}
+            <Controller
+                control={control}
+                rules={{
+                    required: true,
+                }}
+                render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                        label="Email"
+                        placeholder="Email"
+                        onBlur={onBlur}
+                        onChangeText={onChange}
+                        value={value}
+                        autoCapitalize='none'
+                        error={errors.email ? 'Email is required.' : undefined}
+                    />
+                )}
+                name="email"
+            />
+
+            <Controller
+                control={control}
+                rules={{
+                    maxLength: 100,
+                }}
+                render={({ field: { onChange, onBlur, value } }) => (
+                    <Input
+                        label="Password"
+                        placeholder="Password"
+                        onBlur={onBlur}
+                        onChangeText={onChange}
+                        value={value}
+                        autoCapitalize='none'
+                        secureTextEntry
+                        error={errors.password ? 'Password is required.' : undefined}
+                    />
+                )}
+                name="password"
+            />
+
+            <View style={styles.verticallySpaced}>
+                <Button title="Sign up" disabled={loading} onPress={handleSubmit(signUpWithEmail)} />
+                <Link href='/user/signin'>Sign in</Link>
+                <Button title="Resend confirmation email" variant="outline" onPress={handleSubmit(resendConfirmationEmail)} />
+            </View>
+        </>
+    )
+}

--- a/src/components/user/styles.ts
+++ b/src/components/user/styles.ts
@@ -1,0 +1,47 @@
+import {StyleSheet} from "react-native";
+
+export const styles = StyleSheet.create({
+    container: {
+        flex: 1,
+        padding: 16,
+    },
+    header: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        paddingBottom: 16,
+        borderBottomWidth: 1,
+        borderBottomColor: 'rgba(0, 0, 0, 0.1)',
+    },
+    closeButton: {
+        padding: 8,
+    },
+    formContainer: {
+        flex: 1,
+        paddingTop: 16,
+    },
+    verticallySpaced: {
+        paddingTop: 4,
+        paddingBottom: 4,
+        alignSelf: 'stretch',
+    },
+    mt20: {
+        marginTop: 20,
+    },
+    errorContainer: {
+        marginTop: 8,
+    },
+    successContainer: {
+        marginTop: 8,
+    },
+    loadingOverlay: {
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        right: 0,
+        bottom: 0,
+        justifyContent: 'center',
+        alignItems: 'center',
+        backgroundColor: 'rgba(255,255,255,0.6)',
+    },
+});

--- a/src/context/ThemeContext.tsx
+++ b/src/context/ThemeContext.tsx
@@ -4,7 +4,7 @@ import { lightTheme, darkTheme, Theme } from '../theme';
 
 export type ThemeMode = 'light' | 'dark' | 'system';
 
-interface ThemeContextType {
+export interface ThemeContextType {
   theme: Theme;
   themeMode: ThemeMode;
   setThemeMode: (mode: ThemeMode) => void;

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,0 +1,13 @@
+import { Session } from '@supabase/supabase-js'
+import { createContext, useContext } from 'react'
+import {AuthContext} from "../providers/auth-provider";
+
+export type AuthData = {
+    session?: Session | null
+    profile?: any | null
+    isLoading: boolean
+    isLoggedIn: boolean
+}
+
+
+export const useAuth = () => useContext(AuthContext)

--- a/src/providers/auth-provider.tsx
+++ b/src/providers/auth-provider.tsx
@@ -1,0 +1,73 @@
+import {createContext, PropsWithChildren, useEffect, useState} from "react";
+import {Session} from "@supabase/supabase-js";
+import {supabase} from "../supabase";
+import {AuthData} from "../hooks/useAuth";
+
+export const AuthContext = createContext<AuthData>({
+    session: undefined,
+    profile: undefined,
+    isLoading: true,
+    isLoggedIn: false,
+});
+
+export default function AuthProvider({ children }: PropsWithChildren) {
+    const [session, setSession] = useState<Session | undefined | null>()
+    const [profile, setProfile] = useState<any>()
+    const [isLoading, setIsLoading] = useState<boolean>(true)
+    // Fetch the session once, and subscribe to auth state changes
+    useEffect(() => {
+        const fetchSession = async () => {
+            setIsLoading(true)
+            const {
+                data: { session },
+                error,
+            } = await supabase.auth.getSession()
+            if (error) {
+                console.error('Error fetching session:', error)
+            }
+            setSession(session)
+            setIsLoading(false)
+        }
+        fetchSession()
+        const {
+            data: { subscription },
+        } = supabase.auth.onAuthStateChange((_event, session) => {
+            console.log('Auth state changed:', { event: _event, session })
+            setSession(session)
+        })
+        // Cleanup subscription on unmount
+        return () => {
+            subscription.unsubscribe()
+        }
+    }, [])
+    // Fetch the profile when the session changes
+    useEffect(() => {
+        const fetchProfile = async () => {
+            setIsLoading(true)
+            if (session) {
+                const { data } = await supabase
+                    .from('profiles')
+                    .select('*')
+                    .eq('id', session.user.id)
+                    .single()
+                setProfile(data)
+            } else {
+                setProfile(null)
+            }
+            setIsLoading(false)
+        }
+        fetchProfile()
+    }, [session])
+    return (
+        <AuthContext.Provider
+            value={{
+                session,
+                isLoading,
+                profile,
+                isLoggedIn: session != undefined,
+            }}
+        >
+            {children}
+        </AuthContext.Provider>
+    )
+}

--- a/src/supabase.ts
+++ b/src/supabase.ts
@@ -1,5 +1,6 @@
-import { createClient } from '@supabase/supabase-js'
-import AsyncStorage from '@react-native-async-storage/async-storage'
+import { createClient } from '@supabase/supabase-js';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {AppState, Platform} from "react-native";
 
 const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL as string;
 const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY as string;
@@ -12,12 +13,43 @@ if (!supabaseAnonKey) {
   throw new Error('Missing EXPO_PUBLIC_SUPABASE_ANON_KEY environment variable');
 }
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
-  auth: {
-    storage: AsyncStorage,
-    autoRefreshToken: true,
-    persistSession: true,
-    detectSessionInUrl: false,
+const ExpoWebSecureStoreAdapter = {
+  getItem: (key: string) => {
+    console.debug("getItem", { key });
+    return AsyncStorage.getItem(key)
   },
-  db: { schema: 'public' }
-})
+  setItem: (key: string, value: string) => {
+    return AsyncStorage.setItem(key, value);
+  },
+  removeItem: (key: string) => {
+    return AsyncStorage.removeItem(key);
+  },
+};
+
+export const supabase = createClient(
+    supabaseUrl,
+    supabaseAnonKey,
+    {
+      auth: {
+          ...(Platform.OS !== "web" ? { storage: ExpoWebSecureStoreAdapter } : {}),
+        autoRefreshToken: true,
+        persistSession: true,
+        detectSessionInUrl: false,
+      },
+      db: { schema: 'public' }
+    });
+
+// Tells Supabase Auth to continuously refresh the session automatically
+// if the app is in the foreground. When this is added, you will continue
+// to receive `onAuthStateChange` events with the `TOKEN_REFRESHED` or
+// `SIGNED_OUT` event if the user's session is terminated. This should
+// only be registered once.
+if (Platform.OS !== "web") {
+    AppState.addEventListener('change', (state) => {
+        if (state === 'active') {
+            supabase.auth.startAutoRefresh()
+        } else {
+            supabase.auth.stopAutoRefresh()
+        }
+    })
+}


### PR DESCRIPTION
Still very much WIP -- but pulled over Joe's work and used routing instead of modals to control the flow of the work. Also dropping in https://react-hook-form.com/ to make form management, feedback and validation a little simpler.

There are now a few new routes:
- user/signup -- for setting up new users with either email or Google social OAUTH
- user/signin -- for existing users
- user/reset -- for resetting password
- (private)/profile -- will eventually be the profile and settings page. this is a protected route that can only be accessed if a user is authenticated. any routes in this folder should be protected, so features for only authenticated users.
